### PR TITLE
FW-157 Expand image credit field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 /solr/pids
 /solr/test
 /undefined
+
+# additional
+/config/database.yml

--- a/app/forms/admin/essay_image_form.rb
+++ b/app/forms/admin/essay_image_form.rb
@@ -9,7 +9,7 @@ class Admin::EssayImageForm
   attr_accessor :essay
   attr_accessor :cover_image_alt, :cover_image_credit, :cover_image, :author_image
 
-  validates :cover_image_credit, :cover_image_alt, length: { maximum: 250 }
+  validates :cover_image_alt, length: { maximum: 250 }
 
   def self.build(controller)
     essay = EssayQuery.find(controller.params[:id])

--- a/db/migrate/20160621013228_alter_essay_cover_image_credit_type_to_text.rb
+++ b/db/migrate/20160621013228_alter_essay_cover_image_credit_type_to_text.rb
@@ -1,0 +1,5 @@
+class AlterEssayCoverImageCreditTypeToText < ActiveRecord::Migration
+  def change
+    change_column :essays, :cover_image_credit, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150122151000) do
+ActiveRecord::Schema.define(version: 20160621013228) do
 
   create_table "attached_files", force: true do |t|
     t.string   "file_file_name"
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 20150122151000) do
     t.string   "cover_image_content_type"
     t.integer  "cover_image_file_size"
     t.datetime "cover_image_updated_at"
-    t.string   "cover_image_credit"
+    t.text     "cover_image_credit"
     t.string   "cover_image_alt"
     t.string   "author_image_file_name"
     t.string   "author_image_content_type"

--- a/spec/view_models/essay_detail/instructor_resources_spec.rb
+++ b/spec/view_models/essay_detail/instructor_resources_spec.rb
@@ -116,10 +116,10 @@ describe EssayDetail::InstructorResources do
       subject.render
     end
 
-
     it "renders with out error " do
+      file = attached_file(title: "test", file: double(EssayDetail::DownloadFile, url: "test"), body: "test")
+      expect(essay).to receive(:instructor_resources_files).and_return([file])
       expect { subject.render }.to_not raise_error
     end
-
   end
 end

--- a/spec/view_models/essay_detail/nav_spec.rb
+++ b/spec/view_models/essay_detail/nav_spec.rb
@@ -4,7 +4,7 @@ describe EssayDetail::Nav do
 
   let(:issue) { double(Issue, friendly_id: 'fid', title: 'title')}
   let(:essay_style) { double(EssayDetail, id: 1, friendly_id: 'efid', title: 'title')}
-  let(:essay) { double(Essay, title: 'test title', body: double(MarkdownContent, content: "body"), issue: issue, friendly_id: 'essay_fid', essay_style: essay_style, instructor_resources: double(MarkdownContent, content: ""), discussion_questions: double(MarkdownContent, content: ""), author_biography: double(MarkdownContent, content: ""), works_cited: double(MarkdownContent, content: "")) }
+  let(:essay) { double(Essay, instructor_resources_files: nil, title: 'test title', body: double(MarkdownContent, content: "body"), issue: issue, friendly_id: 'essay_fid', essay_style: essay_style, instructor_resources: double(MarkdownContent, content: ""), discussion_questions: double(MarkdownContent, content: ""), author_biography: double(MarkdownContent, content: ""), works_cited: double(MarkdownContent, content: "")) }
 
   subject { described_class.new(essay) }
 

--- a/spec/view_models/essay_search_spec.rb
+++ b/spec/view_models/essay_search_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe EssaySearch do
-  it 'has specs'
-
-  it 'paginates results'
-end


### PR DESCRIPTION
What: The image credit field needed to be expanded in order to allow the editor to add extended caption information, such as for copyright information.
How: Created migration, updated specs, and modified data entry form